### PR TITLE
pt: search: fix cut_before() searching out of range

### DIFF
--- a/pt.py
+++ b/pt.py
@@ -367,13 +367,13 @@ class PageTableDump(gdb.Command):
         if args.after:
             filters.append(lambda page: args.after[0] < page.va + page.page_size)
             min_address = max(args.after[0], min_address)
-        else:
+        elif not args.range:
             min_address = None
 
         if args.before:
             filters.append(lambda page: args.before[0] > page.va)
             max_address = min(args.before[0], max_address)
-        else:
+        elif not args.range:
             max_address = None
 
         if args.filter:

--- a/pt_common.py
+++ b/pt_common.py
@@ -147,16 +147,17 @@ class Page():
         i = len(self.phys) - 1
         off = 0
         while i >= 0:
-            if self.va < cut_addr:
+            if self.va + self.page_size - off - self.sizes[i] < cut_addr:
                 break
             off += self.sizes[i]
             i -= 1
-        if i > 0:
-            self.phys = self.phys[:i]
-            self.sizes = self.sizes[:i]
+        if i < len(self.phys) - 1:
+            self.phys = self.phys[:i + 1]
+            self.sizes = self.sizes[:i + 1]
         delta = 0
         if len(self.phys) >= 1:
-            delta = max(0, (self.va + self.page_size - off) - cut_addr)
+            end_of_last = self.va + self.page_size - off
+            delta = max(0, end_of_last - cut_addr)
             self.sizes[-1] = self.sizes[-1] - delta
         self.page_size = min(self.page_size, cut_addr - self.va)
 


### PR DESCRIPTION
When using `pt -s8 <val> -range <a> <b>`, cut_before() fails to properly trim sub-pages beyond the upper bound. The loop condition `self.va < cut_addr` compares the start of the entire range against the cut address, which is almost always true immediately, so the loop never removes any sub-pages from the end. This causes read_memory() to read past the intended boundary and search_memory() to report matches outside the specified range.

Fix the loop condition to correctly check whether each sub-page (iterating from the end) starts before the cut address, and fix the slice index to keep the last valid sub-page rather than discarding it.